### PR TITLE
Add speed to RellaxWrapperProps interface

### DIFF
--- a/src/rellaxWrapper.tsx
+++ b/src/rellaxWrapper.tsx
@@ -10,6 +10,7 @@ interface RellaxWrapperProps extends Rellax.RellaxOptions {
   tablet?: number;
   desktop?: number;
   style?: React.CSSProperties;
+  speed?: number;
 }
 
 const RellaxWrapper: FC<RellaxWrapperProps> = ({


### PR DESCRIPTION
# Summary
`speed` is not available through props, but it's used inside the markup. 

This PR enables valid usage of `speed` prop in TS environments. 